### PR TITLE
fix(api): disable CORS credentials with wildcard origins

### DIFF
--- a/devduck/api/vapi_webhook.py
+++ b/devduck/api/vapi_webhook.py
@@ -25,7 +25,9 @@ app = FastAPI(title="DevDuck API", version="0.1.0")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
-    allow_credentials=True,
+    # Credentials must stay disabled while origins is a wildcard; otherwise
+    # any website can make credentialed requests against this local API.
+    allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/devduck/api/vapi_webhook.py
+++ b/devduck/api/vapi_webhook.py
@@ -427,7 +427,7 @@ async def vapi_webhook(request: Request):
         return {"success": True, "message": "Webhook received"}
 
     except Exception as e:
-        logger.error("Error processing VAPI webhook: %s", str(e))
+        logger.exception("Error processing VAPI webhook")
         raise HTTPException(
             status_code=500, detail=f"Webhook processing error: {str(e)}") from e
 
@@ -481,7 +481,7 @@ def get_code_snippet(request: FunctionCallRequest):
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail="File not found") from exc
     except Exception as e:
-        logger.error("Error reading file: %s", e)
+        logger.exception("Error reading file")
         raise HTTPException(
             status_code=500, detail="Internal server error") from e
 


### PR DESCRIPTION
## Summary
The FastAPI app configured CORS with `allow_origins=["*"]` **and** `allow_credentials=True`. In that combination Starlette reflects whatever `Origin` header the request carries and sets `Access-Control-Allow-Credentials: true`, which means any website a user visits can make credentialed cross-origin requests to the local DevDuck API (read conversation history, trigger duck routines, etc.).

This change sets `allow_credentials=False`. The API uses no cookies, sessions, or auth headers, so nothing depends on credentialed requests — the Electron frontend and VAPI webhook calls are unaffected.

## Verification
Tested header behavior with Starlette's `TestClient`:
- Before: `Access-Control-Allow-Origin: https://evil.example` + `Access-Control-Allow-Credentials: true` (origin reflected)
- After: `Access-Control-Allow-Origin: *`, no credentials header

https://claude.ai/code/session_016G2TQKFwzn3wYd5oTzmkRj

---
_Generated by [Claude Code](https://claude.ai/code/session_016G2TQKFwzn3wYd5oTzmkRj)_