### PR TITLE
fix(api): restrict /get_code_snippet to workspace root and bind loopback by default

### DIFF
--- a/devduck/api/vapi_webhook.py
+++ b/devduck/api/vapi_webhook.py
@@ -4,9 +4,11 @@ FastAPI app for DevDuck: VAPI webhook and basic endpoints
 
 import json
 import logging
+import os
 import threading
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from fastapi import FastAPI, HTTPException, Request
@@ -31,6 +33,11 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Files served by /get_code_snippet must live under this directory tree;
+# anything outside it (including via .. traversal or symlinks) is rejected.
+WORKSPACE_ROOT = Path(
+    os.getenv("DEVDUCK_WORKSPACE_ROOT", os.getcwd())).resolve()
 
 # --- Application state management ---
 
@@ -469,13 +476,18 @@ async def duck_gesture(name: str):
 
 @app.post("/get_code_snippet")
 def get_code_snippet(request: FunctionCallRequest):
-    """Retrieve a code snippet from a given file path."""
+    """Retrieve a code snippet from a file inside the workspace root."""
     file_path = request.parameters.get("file_path")
     if not file_path:
         raise HTTPException(status_code=400, detail="File path is required")
 
+    resolved = (WORKSPACE_ROOT / file_path).resolve()
+    if resolved != WORKSPACE_ROOT and WORKSPACE_ROOT not in resolved.parents:
+        raise HTTPException(
+            status_code=403, detail="File path is outside the workspace root")
+
     try:
-        with open(file_path, "r", encoding="utf-8") as file:
+        with open(resolved, "r", encoding="utf-8") as file:
             code_snippet = file.read()
         return {"success": True, "code_snippet": code_snippet}
     except FileNotFoundError as exc:
@@ -517,4 +529,6 @@ def retrieve_context(request: FunctionCallRequest):
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    # Loopback by default; set DEVDUCK_API_HOST=0.0.0.0 only when the API
+    # is intentionally exposed (e.g. behind ngrok for VAPI webhooks).
+    uvicorn.run(app, host=os.getenv("DEVDUCK_API_HOST", "127.0.0.1"), port=8000)

--- a/devduck/api/vapi_webhook.py
+++ b/devduck/api/vapi_webhook.py
@@ -36,8 +36,7 @@ app.add_middleware(
 
 # Files served by /get_code_snippet must live under this directory tree;
 # anything outside it (including via .. traversal or symlinks) is rejected.
-WORKSPACE_ROOT = Path(
-    os.getenv("DEVDUCK_WORKSPACE_ROOT", os.getcwd())).resolve()
+WORKSPACE_ROOT = Path(os.getenv("DEVDUCK_WORKSPACE_ROOT", os.getcwd())).resolve()
 
 # --- Application state management ---
 
@@ -531,4 +530,8 @@ if __name__ == "__main__":
     import uvicorn
     # Loopback by default; set DEVDUCK_API_HOST=0.0.0.0 only when the API
     # is intentionally exposed (e.g. behind ngrok for VAPI webhooks).
-    uvicorn.run(app, host=os.getenv("DEVDUCK_API_HOST", "127.0.0.1"), port=8000)
+    uvicorn.run(
+        app,
+        host=os.getenv("DEVDUCK_API_HOST", "127.0.0.1"),
+        port=int(os.getenv("DEVDUCK_API_PORT", "8001")),
+    )

--- a/devduck/api/vapi_webhook.py
+++ b/devduck/api/vapi_webhook.py
@@ -477,20 +477,31 @@ async def duck_gesture(name: str):
 def get_code_snippet(request: FunctionCallRequest):
     """Retrieve a code snippet from a file inside the workspace root."""
     file_path = request.parameters.get("file_path")
-    if not file_path:
-        raise HTTPException(status_code=400, detail="File path is required")
+    if not file_path or not isinstance(file_path, str):
+        raise HTTPException(
+            status_code=400, detail="File path must be a non-empty string")
 
     resolved = (WORKSPACE_ROOT / file_path).resolve()
     if resolved != WORKSPACE_ROOT and WORKSPACE_ROOT not in resolved.parents:
         raise HTTPException(
             status_code=403, detail="File path is outside the workspace root")
+    if resolved.is_dir():
+        raise HTTPException(
+            status_code=400, detail="File path refers to a directory")
 
     try:
-        with open(resolved, "r", encoding="utf-8") as file:
+        # O_NOFOLLOW rejects a symlink swapped in for the final path
+        # component between the allowlist check above and this open.
+        fd = os.open(resolved, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        with os.fdopen(fd, "r", encoding="utf-8") as file:
             code_snippet = file.read()
         return {"success": True, "code_snippet": code_snippet}
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail="File not found") from exc
+    except OSError as exc:
+        # ELOOP from O_NOFOLLOW, a directory raced in post-check, etc.
+        raise HTTPException(
+            status_code=403, detail="File is not readable") from exc
     except Exception as e:
         logger.exception("Error reading file")
         raise HTTPException(

--- a/scripts/start_api.py
+++ b/scripts/start_api.py
@@ -10,13 +10,17 @@ import uvicorn
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 if __name__ == "__main__":
-    print("🦆 Starting DevDuck API server...")
+    # Loopback by default; set DEVDUCK_API_HOST=0.0.0.0 only when the API
+    # is intentionally exposed (e.g. behind ngrok for VAPI webhooks).
+    host = os.getenv("DEVDUCK_API_HOST", "127.0.0.1")
+
+    print("\U0001F986 Starting DevDuck API server...")
     print("API will be available at: http://localhost:8001")
     print("Press Ctrl+C to stop")
 
     uvicorn.run(
         "devduck.api.vapi_webhook:app",
-        host="0.0.0.0",
+        host=host,
         port=8001,
         reload=True,
         log_level="info"

--- a/scripts/start_api.py
+++ b/scripts/start_api.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
     # is intentionally exposed (e.g. behind ngrok for VAPI webhooks).
     host = os.getenv("DEVDUCK_API_HOST", "127.0.0.1")
 
-    print("\U0001F986 Starting DevDuck API server...")
+    print("🦆 Starting DevDuck API server...")
     print("API will be available at: http://localhost:8001")
     print("Press Ctrl+C to stop")
 

--- a/scripts/start_api.py
+++ b/scripts/start_api.py
@@ -13,15 +13,17 @@ if __name__ == "__main__":
     # Loopback by default; set DEVDUCK_API_HOST=0.0.0.0 only when the API
     # is intentionally exposed (e.g. behind ngrok for VAPI webhooks).
     host = os.getenv("DEVDUCK_API_HOST", "127.0.0.1")
+    port = int(os.getenv("DEVDUCK_API_PORT", "8001"))
+    display_host = "localhost" if host == "0.0.0.0" else host
 
     print("🦆 Starting DevDuck API server...")
-    print("API will be available at: http://localhost:8001")
+    print(f"API will be available at: http://{display_host}:{port}")
     print("Press Ctrl+C to stop")
 
     uvicorn.run(
         "devduck.api.vapi_webhook:app",
         host=host,
-        port=8001,
+        port=port,
         reload=True,
         log_level="info"
     )


### PR DESCRIPTION
Implements the interim mitigations from #14 (the full shared-secret auth scheme remains tracked there):

- **`/get_code_snippet` path hardening** — requested paths are now resolved against a `DEVDUCK_WORKSPACE_ROOT` allowlisted directory (default: the server's working directory). `../` traversal, absolute paths outside the root, and symlink escapes are rejected with `403`. Previously any caller could read any file on disk readable by the server process.
- **Loopback binding by default** — both `scripts/start_api.py` and the `__main__` runner now bind `127.0.0.1` instead of `0.0.0.0`. Set `DEVDUCK_API_HOST=0.0.0.0` to opt back in when intentionally exposing the API (e.g. behind ngrok for VAPI webhooks).

Tested with FastAPI's `TestClient`: relative/absolute paths inside the root return 200; `../` traversal, absolute escapes, and symlinks pointing outside the root return 403; missing files inside the root return 404; missing `file_path` returns 400.

Refs #14

https://claude.ai/code/session_01DFwCn17gekNRatF9DuN26J

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFwCn17gekNRatF9DuN26J)_