### PR TITLE
fix: read VAPI key from environment instead of demo_key fallback

### DIFF
--- a/devduck/main.py
+++ b/devduck/main.py
@@ -6,6 +6,7 @@ Main application that coordinates the API server and basic functionality.
 
 import asyncio
 import logging
+import os
 import threading
 import time
 from typing import Optional
@@ -24,7 +25,11 @@ logger = logging.getLogger(__name__)
 class DevDuckApplication:
     """Main DevDuck application class coordinating components."""
     def __init__(self, api_key: Optional[str] = None):
-        self.api_key = api_key or "demo_key"
+        self.api_key = api_key or os.environ.get("VAPI_API_KEY", "")
+        if not self.api_key:
+            logger.warning(
+                "No VAPI API key configured (set VAPI_API_KEY); "
+                "running without one")
         self.vapi_client = VAPIClient(self.api_key)
         self.is_running = False
         logger.info("DevDuck application initialized")

--- a/devduck/main.py
+++ b/devduck/main.py
@@ -25,7 +25,9 @@ logger = logging.getLogger(__name__)
 class DevDuckApplication:
     """Main DevDuck application class coordinating components."""
     def __init__(self, api_key: Optional[str] = None):
-        self.api_key = api_key or os.environ.get("VAPI_API_KEY", "")
+        resolved_key = api_key if api_key is not None else os.environ.get(
+            "VAPI_API_KEY", "")
+        self.api_key = resolved_key.strip()
         if not self.api_key:
             logger.warning(
                 "No VAPI API key configured (set VAPI_API_KEY); "


### PR DESCRIPTION
## Summary
`DevDuckApplication` silently fell back to a hardcoded `"demo_key"` string when no API key was passed. The key now comes from the `VAPI_API_KEY` env var (the name already documented in `.env.example`), with a warning logged when unset — consistent with how `vapi_webhook.py` loads its token from the environment.

Since the current `VAPIClient` is a stub that doesn't make authenticated calls, this intentionally warns rather than raises, so the demo flow keeps working without a key. If/when the client makes real VAPI calls, this should be promoted to a hard error like the webhook's `RuntimeError` pattern.

## Testing
- `python -m pytest tests/` — 3 passed
- `python -m py_compile devduck/main.py` clean

https://claude.ai/code/session_019Z1uLShTHyrjZg925Hf4NU

---
_Generated by [Claude Code](https://claude.ai/code/session_019Z1uLShTHyrjZg925Hf4NU)_