### PR TITLE
Fix webhook 500s on bad input and unbuildable requirements install

### DIFF
--- a/devduck/api/vapi_webhook.py
+++ b/devduck/api/vapi_webhook.py
@@ -253,6 +253,10 @@ def handle_suggest_break(params: Dict[str, Any]) -> Dict[str, Any]:
     """Handle break suggestion requests"""
     stress_level = params.get('stress_level', 'medium')
     work_duration = params.get('work_duration', 60)
+    try:
+        work_duration = float(work_duration)
+    except (TypeError, ValueError):
+        work_duration = 60
 
     suggestions = {
         "low": "You're doing great! Consider a 5-minute stretch break.",
@@ -515,6 +519,10 @@ async def vapi_webhook(request: Request):
 
         return {"success": True, "message": "Webhook received"}
 
+    except json.JSONDecodeError as e:
+        logger.warning("Received VAPI webhook with invalid JSON body: %s", e)
+        raise HTTPException(
+            status_code=400, detail="Invalid JSON in request body") from e
     except Exception as e:
         logger.exception("Error processing VAPI webhook")
         raise HTTPException(

--- a/devduck/api/vapi_webhook.py
+++ b/devduck/api/vapi_webhook.py
@@ -3,6 +3,7 @@ FastAPI app for DevDuck: VAPI webhook and basic endpoints
 """
 
 import json
+import math
 import logging
 import os
 import secrets
@@ -255,8 +256,10 @@ def handle_suggest_break(params: Dict[str, Any]) -> Dict[str, Any]:
     work_duration = params.get('work_duration', 60)
     try:
         work_duration = float(work_duration)
+        if not math.isfinite(work_duration):
+            work_duration = 60.0
     except (TypeError, ValueError):
-        work_duration = 60
+        work_duration = 60.0
 
     suggestions = {
         "low": "You're doing great! Consider a 5-minute stretch break.",
@@ -526,7 +529,7 @@ async def vapi_webhook(request: Request):
     except Exception as e:
         logger.exception("Error processing VAPI webhook")
         raise HTTPException(
-            status_code=500, detail=f"Webhook processing error: {str(e)}") from e
+            status_code=500, detail="Internal error processing webhook") from e
 
 
 @app.post("/duck/talk/start")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,15 @@ pydantic>=1.8.0
 python-dotenv>=0.19.0
 loguru>=0.6.0
 pytest>=6.0.0
+httpx>=0.24.0
 black>=21.0.0
 flake8>=3.9.0
 aiofiles>=0.5.0
-vapi-python>=0.1.9
+# Optional: vapi-python is not imported by the codebase yet and pulls in
+# pyaudio, which fails to build without the PortAudio system headers.
+# Install it manually when voice calling is needed:
+#   pip install vapi-python
+# vapi-python>=0.1.9
 flask>=2.0.0
 PyYAML>=5.4.1
 pyserial>=3.5


### PR DESCRIPTION
## Testing summary

- Created a fresh venv; `pip install -r requirements.txt` **failed** out of the box: `vapi-python` pulls in `pyaudio`, which cannot build without PortAudio system headers, aborting the whole install. Installed the remaining dependencies individually to proceed.
- Ran the existing suite: `pytest tests/` — 3/3 passed.
- Compile-checked all Python sources (`py_compile`) — clean.
- Smoke-tested every API endpoint via FastAPI TestClient, including edge cases: auth required/bypass, empty webhook body, malformed JSON, unknown functions, missing parameters, path traversal on `/get_code_snippet` (correctly 403), missing files, directories, missing/unknown context IDs, unknown gestures, and talk-animation start/stop. Hardware (serial duck) and live VAPI calls were not exercisable in this environment.

## Bugs found and fixed

1. **Malformed JSON to `/webhook/vapi` returned 500.** The generic exception handler turned a client error into a server error. Now returns 400 with a clear message.
2. **String `work_duration` crashed `handle_suggest_break`.** Webhook payloads commonly carry numeric parameters as strings; `"180" > 120` raised `TypeError` and produced a 500. The value is now coerced safely, falling back to the default.
3. **`pip install -r requirements.txt` broken by unused dependency.** `vapi-python` is not imported anywhere in the codebase but breaks the entire install on systems without PortAudio headers. It is now commented out with instructions to install manually when voice calling is added.
4. **Missing test dependency.** `fastapi.testclient` requires `httpx`, which was not in requirements, so the existing test suite could not run on a clean install. Added `httpx>=0.24.0`.

https://claude.ai/code/session_01Pdr2u5eE9XswikXHCjZNs5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pdr2u5eE9XswikXHCjZNs5)_