### PR TITLE
fix(api): read assistant serverUrl from VAPI_WEBHOOK_URL env var

### DIFF
--- a/devduck/api/assistant_config.py
+++ b/devduck/api/assistant_config.py
@@ -5,6 +5,8 @@ This module contains the assistant configuration that can be used
 to create or update the VAPI assistant.
 """
 
+import os
+
 DEVDUCK_ASSISTANT_CONFIG = {
     "name": "DevDuck",
     "model": {
@@ -41,7 +43,9 @@ Always prioritize the developer's well-being alongside their technical needs."""
         "voiceId": "jennifer"
     },
     "firstMessage": "Hi! I'm DevDuck, your AI debugging buddy. I'm here to help you with code, provide encouragement, and make sure you're taking care of yourself while coding. What are you working on today?",
-    "serverUrl": "https://4e3e6f218d9f.ngrok-free.app/webhook/vapi",
+    # Webhook endpoint VAPI calls back. Configure VAPI_WEBHOOK_URL (e.g. an
+    # ngrok tunnel) in production; defaults to the local API server.
+    "serverUrl": os.getenv("VAPI_WEBHOOK_URL", "http://localhost:8001/webhook/vapi"),
     "functions": [
         {
             "name": "analyze_code",

--- a/devduck/api/assistant_config.py
+++ b/devduck/api/assistant_config.py
@@ -7,6 +7,13 @@ to create or update the VAPI assistant.
 
 import os
 
+# Local API server URL used as the webhook fallback when VAPI_WEBHOOK_URL is
+# unset. The port mirrors DEVDUCK_API_PORT (see scripts/start_api.py) so the
+# two stay in sync if the API runs on a non-default port.
+_DEFAULT_WEBHOOK_URL = (
+    f"http://localhost:{os.getenv('DEVDUCK_API_PORT', '8001')}/webhook/vapi"
+)
+
 DEVDUCK_ASSISTANT_CONFIG = {
     "name": "DevDuck",
     "model": {
@@ -43,9 +50,10 @@ Always prioritize the developer's well-being alongside their technical needs."""
         "voiceId": "jennifer"
     },
     "firstMessage": "Hi! I'm DevDuck, your AI debugging buddy. I'm here to help you with code, provide encouragement, and make sure you're taking care of yourself while coding. What are you working on today?",
-    # Webhook endpoint VAPI calls back. Configure VAPI_WEBHOOK_URL (e.g. an
-    # ngrok tunnel) in production; defaults to the local API server.
-    "serverUrl": os.getenv("VAPI_WEBHOOK_URL", "http://localhost:8001/webhook/vapi"),
+    # Webhook endpoint VAPI calls back. Set VAPI_WEBHOOK_URL to a publicly
+    # reachable URL (e.g. an ngrok dev tunnel) when running VAPI against this
+    # server; otherwise it defaults to the local API server.
+    "serverUrl": os.getenv("VAPI_WEBHOOK_URL", _DEFAULT_WEBHOOK_URL),
     "functions": [
         {
             "name": "analyze_code",


### PR DESCRIPTION
## Summary

`devduck/api/assistant_config.py` hardcoded an ephemeral ngrok tunnel URL as the assistant's `serverUrl`:

```python
"serverUrl": "https://4e3e6f218d9f.ngrok-free.app/webhook/vapi",
```

ngrok-free subdomains rotate, so the committed value is dead infrastructure config — anyone running the project would push a stale webhook URL to VAPI. The repo already documents `VAPI_WEBHOOK_URL` in `.env.example`, so this reads from that env var instead, with a localhost fallback matching the API server's default port (`8001`, per `scripts/start_api.py`).

## Changes
- `import os` and `serverUrl = os.getenv("VAPI_WEBHOOK_URL", "http://localhost:8001/webhook/vapi")`.

## Why
Removes leaked/stale infra config from source control and makes the webhook target configurable per environment without code edits.

## Testing
- Not a secret (ngrok-free subdomains are public and ephemeral), so no rotation needed.
- The config dict is otherwise unchanged; only the `serverUrl` value resolution differs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNSSo3EVcHGq54H9hiVoSj)_